### PR TITLE
Support POST request in NotifyAction

### DIFF
--- a/Action/NotifyAction.php
+++ b/Action/NotifyAction.php
@@ -38,7 +38,7 @@ class NotifyAction implements ActionInterface, ApiAwareInterface, GatewayAwareIn
 
         $this->gateway->execute($httpRequest = new GetHttpRequest());
 
-        $response = $this->api->doNotify($httpRequest->query);
+        $response = $this->api->doNotify($httpRequest->method === 'POST' ? $httpRequest->request : $httpRequest->query);
 
         if (!$response) {
             throw new \WebToPayException('Wrong parameters');


### PR DESCRIPTION
Paysera allows configuring webhook requests to be sent via POST request. Currently, such requests fail as request data is only taken from the query param, which is filled when Paysera's project is configured to send webhooks via GET request.

This PR adds support for POST webhook requests.